### PR TITLE
Remove RSE from motivations to attend

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ permalink: /
 navigation_weight: 1
 ---
 
-We invite you to join us for the third online RSEAA Unconference from the **10th to the 13th of September 2024**. This is a joint partnership between the [RSE Asia Association](https://rse-asia.github.io/RSE_Asia/) and the [RSE Association of Australia and New Zealand](https://rse-aunz.github.io/). The theme for this year is "Sharing tech architectures", there is an extra day for a Leaders Forum on the 10th, and the hashtag will be #RSEAA24.
+We invite you to join us for RSEAA24, the third online RSE Asia Australia Unconference, from the **10th to the 13th of September 2024**. This is a joint partnership between the [RSE Asia Association](https://rse-asia.github.io/RSE_Asia/) and the [RSE Association of Australia and New Zealand](https://rse-aunz.github.io/). The theme for this year is "Sharing tech architectures", there is an extra day for a Leaders Forum on the 10th, and the hashtag will be #RSEAA24.
 
 ## Why would someone go to RSEAA24?
 

--- a/index.md
+++ b/index.md
@@ -9,11 +9,11 @@ We invite you to join us for the third online Research Software Engineer (RSE) A
 
 ## Why would someone go to RSEAA24?
 
-Some of the motivations of the RSEs at the conference might include:
-- To talk about difficulties in career progression as a RSE
+Some of the motivations for attending might include:
+- To talk about difficulties in career progression and lack of recognition with others who work in research software
 - To learn how to make their research software more visible
-- To learn about how other RSEs create applications for researchers
-- To learn about how other RSEs might streamline and scale their research workflows
+- To learn about how others create applications for researchers
+- To learn about how others streamline and scale their research workflows
 - To discuss how they balance researcher needs with good software practices
 - To discuss how they make their research software easier to use
 

--- a/index.md
+++ b/index.md
@@ -11,11 +11,11 @@ We invite you to join us for the third online RSEAA Unconference from the **10th
 
 Some of the motivations for attending might include:
 - To talk about difficulties in career progression and lack of recognition with others who work in research software
-- To learn how to make their research software more visible
+- To learn from others how to make their research software more visible
 - To learn about how others create applications for researchers
 - To learn about how others streamline and scale their research workflows
-- To discuss how they balance researcher needs with good software practices
-- To discuss how they make their research software easier to use
+- To discuss with others how they balance researcher needs with good software practices
+- To discuss with others how they make their research software easier to use
 
 ## What is a Research Software Engineer (RSE)? 
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ permalink: /
 navigation_weight: 1
 ---
 
-We invite you to join us for the third online Research Software Engineer (RSE) Asia Australia Unconference from the **10th to the 13th of September 2024**. This is a joint partnership between the [RSE Asia Association](https://rse-asia.github.io/RSE_Asia/) and the [RSE Association of Australia and New Zealand](https://rse-aunz.github.io/). The theme for this year is "Sharing tech architectures", there is an extra day for a Leaders Forum on the 10th, and the hashtag will be #RSEAA24.
+We invite you to join us for the third online RSEAA Unconference from the **10th to the 13th of September 2024**. This is a joint partnership between the [RSE Asia Association](https://rse-asia.github.io/RSE_Asia/) and the [RSE Association of Australia and New Zealand](https://rse-aunz.github.io/). The theme for this year is "Sharing tech architectures", there is an extra day for a Leaders Forum on the 10th, and the hashtag will be #RSEAA24.
 
 ## Why would someone go to RSEAA24?
 
@@ -17,7 +17,7 @@ Some of the motivations for attending might include:
 - To discuss how they balance researcher needs with good software practices
 - To discuss how they make their research software easier to use
 
-## What is a Research Software Engineer? 
+## What is a Research Software Engineer (RSE)? 
 
 Research Software Engineer is a broad term for people who combine programming and research skills that have trouble defining their role and value within academia. e.g 
 - researchers and academics who code,


### PR DESCRIPTION
Remove the word RSE from "Why would someone go to RSEAA24?"

This is because we want to avoid the language of RSE for those who might be "turned off" with the term "RSE".

